### PR TITLE
Allow better time precision in logs

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -84,7 +84,7 @@ func (h *GraylogHandler) Handle(ctx context.Context, record slog.Record) error {
 		Host:     h.option.hostname,
 		Short:    short(&record),
 		Full:     strings.TrimSpace(record.Message),
-		TimeUnix: float64(record.Time.Unix()),
+		TimeUnix: float64(record.Time.UnixNano()) / 1e9,
 		Level:    LogLevels[record.Level],
 		Facility: h.option.Writer.Facility,
 		Extra:    extra,


### PR DESCRIPTION
Previously, the logs were sent with only second precision, which quickly gets suboptimal when dealing with lots of log events happening at more or less the same time.

This patch allows for milliseconds, as it sends the second value _with decimals_.
